### PR TITLE
Add the -n flag

### DIFF
--- a/private/bin/process_transactions.sh
+++ b/private/bin/process_transactions.sh
@@ -24,4 +24,4 @@ while IFS= read -r line; do
         echo "$line"
     fi
 # skip the first line (header)
-done < <(tail +2 "$1")
+done < <(tail -n +2 "$1")


### PR DESCRIPTION
Missing -n flag for the tail command led to `tail: cannot open '+2' for reading: No such file or directory`